### PR TITLE
Document reasoning.effort workaround in OpenAI example comments

### DIFF
--- a/src/csharp/Program.cs
+++ b/src/csharp/Program.cs
@@ -35,6 +35,12 @@ var client = new OpenAIClient(
     new OpenAIClientOptions { Endpoint = new Uri(baseUrl) });
 
 // --- Example 1: OpenAI model (gpt-4.1-mini) ---
+// Note: gpt-4.1-mini is not a reasoning model. If you swap in an OpenAI
+// reasoning model (o4-mini, o3, gpt-5.x), set ReasoningOptions with an effort
+// level (low/medium/high) on CreateResponseOptions to control reasoning compute.
+// Recovering human-readable summary text via ReasoningOptions.Summary currently
+// requires OpenAI organization verification — see
+// https://github.com/Azure-Samples/ai-model-start/issues/13.
 var openaiModel = Environment.GetEnvironmentVariable("AZURE_MODEL_2_DEPLOYMENT_NAME") ?? "gpt-4.1-mini";
 Console.WriteLine($"Example 1: OpenAI model ({openaiModel})\n");
 Console.WriteLine("Waiting for response...");

--- a/src/go/main.go
+++ b/src/go/main.go
@@ -86,6 +86,12 @@ func main() {
 	)
 
 	// --- Example 1: OpenAI model (gpt-4.1-mini) ---
+	// Note: gpt-4.1-mini is not a reasoning model. If you swap in an OpenAI
+	// reasoning model (o4-mini, o3, gpt-5.x), set Reasoning with an Effort level
+	// (low/medium/high) on ResponseNewParams to control reasoning compute.
+	// Recovering human-readable summary text via Reasoning.Summary currently
+	// requires OpenAI organization verification — see
+	// https://github.com/Azure-Samples/ai-model-start/issues/13.
 	openaiModel := os.Getenv("AZURE_MODEL_2_DEPLOYMENT_NAME")
 	if openaiModel == "" {
 		openaiModel = "gpt-4.1-mini"

--- a/src/java/src/main/java/ResponsesExample.java
+++ b/src/java/src/main/java/ResponsesExample.java
@@ -91,6 +91,12 @@ public class ResponsesExample {
                 .build();
 
         // --- Example 1: OpenAI model (gpt-4.1-mini) ---
+        // Note: gpt-4.1-mini is not a reasoning model. If you swap in an OpenAI
+        // reasoning model (o4-mini, o3, gpt-5.x), set .reasoning(Reasoning.builder()
+        // .effort(Reasoning.Effort.MEDIUM).build()) on ResponseCreateParams to control
+        // reasoning compute. Recovering human-readable summary text via
+        // Reasoning.summary currently requires OpenAI organization verification —
+        // see https://github.com/Azure-Samples/ai-model-start/issues/13.
         String openaiModel = System.getenv().getOrDefault("AZURE_MODEL_2_DEPLOYMENT_NAME", "gpt-4.1-mini");
         System.out.printf("Example 1: OpenAI model (%s)%n%n", openaiModel);
         System.out.println("Waiting for response...");

--- a/src/python/responses_example.py
+++ b/src/python/responses_example.py
@@ -76,6 +76,11 @@ def main():
     )
 
     # --- Example 1: OpenAI model (gpt-4.1-mini) ---
+    # Note: gpt-4.1-mini is not a reasoning model. If you swap in an OpenAI
+    # reasoning model (o4-mini, o3, gpt-5.x), pass reasoning={"effort":"low"|
+    # "medium"|"high"} to control reasoning compute. Recovering human-readable
+    # summary text via reasoning.summary currently requires OpenAI organization
+    # verification — see https://github.com/Azure-Samples/ai-model-start/issues/13.
     openai_model = os.environ.get("AZURE_MODEL_2_DEPLOYMENT_NAME", "gpt-4.1-mini")
     print(f"Example 1: OpenAI model ({openai_model})\n")
     print("Waiting for response...", flush=True)

--- a/src/typescript/responses_example.ts
+++ b/src/typescript/responses_example.ts
@@ -76,6 +76,11 @@ async function main() {
   });
 
   // --- Example 1: OpenAI model (gpt-4.1-mini) ---
+  // Note: gpt-4.1-mini is not a reasoning model. If you swap in an OpenAI
+  // reasoning model (o4-mini, o3, gpt-5.x), pass reasoning: { effort: "low" |
+  // "medium" | "high" } to control reasoning compute. Recovering human-readable
+  // summary text via reasoning.summary currently requires OpenAI organization
+  // verification — see https://github.com/Azure-Samples/ai-model-start/issues/13.
   const openaiModel = process.env.AZURE_MODEL_2_DEPLOYMENT_NAME ?? "gpt-4.1-mini";
   console.log(`Example 1: OpenAI model (${openaiModel})\n`);
   console.log("Waiting for response...");


### PR DESCRIPTION
Adds a brief comment above Example 1 in all 5 language samples (Python, TypeScript, C#, Java, Go) explaining that the default OpenAI model (gpt-4.1-mini) is not a reasoning model, and pointing developers who swap in an OpenAI reasoning model (o4-mini, o3, gpt-5.x) at the reasoning.effort parameter to control compute.

Comments-only change, no functional code modified. Cross-references #13 for the summary-text caveat. Verified via the Known Issues table in the README (added in #11).